### PR TITLE
include human-readable description of cron expression if valid, reaso…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,9 @@ subprojects {
 
     dependencies {
         spinnaker.group('spockBase')
+        spinnaker.group('test')
         compile spinnaker.dependency('slf4jApi')
+        compile 'net.redhogs.cronparser:cron-parser-core:2.8'
         testCompile spinnaker.dependency('slf4jSimple')
         testCompile spinnaker.dependency('groovy')
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Nov 19 12:37:48 PST 2015
+#Wed Jan 06 11:54:05 PST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-all.zip

--- a/scheduled-actions-web/src/test/groovy/com/netflix/scheduledactions/web/controllers/ValidationControllerSpec.groovy
+++ b/scheduled-actions-web/src/test/groovy/com/netflix/scheduledactions/web/controllers/ValidationControllerSpec.groovy
@@ -1,0 +1,42 @@
+package com.netflix.scheduledactions.web.controllers
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.test.web.servlet.MvcResult
+import spock.lang.Shared
+import spock.lang.Specification
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+class ValidationControllerSpec extends Specification {
+
+  @Shared ObjectMapper objectMapper = new ObjectMapper()
+
+  @Shared def mvc = MockMvcBuilders.standaloneSetup(new ValidationController()).build()
+
+  MvcResult validate(String expression) {
+    mvc.perform(MockMvcRequestBuilders
+        .get("/validateCronExpression")
+        .param("cronExpression", expression)).andReturn()
+  }
+
+  void 'should include description when expression is valid'() {
+    when:
+    def result = validate("0 0 10 ? * 1")
+
+    def responseBody = objectMapper.readValue(result.response.contentAsByteArray, Map)
+
+    then:
+    responseBody.response == "Cron expression is valid"
+    responseBody.description == "At 10:00 AM, only on Sunday"
+  }
+
+  void 'should include failure message when expression is invalid'() {
+    when:
+    def result = validate("0 0 10 * * 1")
+
+    then:
+    result.response.status == 400
+    result.response.errorMessage == "Cron expression '0 0 10 * * 1' is not valid: Support for specifying both a " +
+        "day-of-week AND a day-of-month parameter is not implemented."
+  }
+}


### PR DESCRIPTION
…n if not

This will still require some changes to gate to propagate the description, but here's what the response looks like today for the expression `0 0 10 ? * 1`:
```javascript
{
  "response": "Cron expression is valid"
}
```
WIth this PR, it changes to:
```javascript
{
  "response": "Cron expression is valid",
  "description": "At 10:00 AM, only on Sunday"
}
```

For errors, e.g. `0 0 10 * * 1`, we don't get a message back right now because we are just using the `@ResponseStatus` annotation, which doesn't seem to allow a custom message to be passed back in the response. So I'm switching those to `@ExceptionHandler`s, which allow us to set the message on the response and send back a helpful message to the user, e.g. 
```
Cron expression '0 0 10 * * 1' is not valid: Support for specifying both a day-of-week AND a day-of-month parameter is not implemented.
```
I think this was the original intent of the validation controller. It was just never fully implemented.

@cfieber or @ajordens or anyone else, please review