### PR TITLE
Support updates on ActionInstances with predefined ID in InMemory DAO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ build/
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+.idea

--- a/scheduled-actions-core/scheduled-actions-core.gradle
+++ b/scheduled-actions-core/scheduled-actions-core.gradle
@@ -15,7 +15,7 @@
  */
 
 dependencies {
-    compile "com.netflix.fenzo:fenzo-triggers:0.7.8"
+    compile "com.netflix.fenzo:fenzo-triggers:0.11.7"
     compile spinnaker.dependency('rxJava')
     spinnaker.group('jackson')
 }

--- a/scheduled-actions-core/src/main/java/com/netflix/scheduledactions/persistence/AbstractInMemoryDao.java
+++ b/scheduled-actions-core/src/main/java/com/netflix/scheduledactions/persistence/AbstractInMemoryDao.java
@@ -85,6 +85,10 @@ public abstract class AbstractInMemoryDao<T> {
         return items;
     }
 
+    protected boolean isIdFormat(String id) {
+        return id.contains(idSeparator);
+    }
+
     protected String createId(String group, String id) {
         if (group == null || id == null || group.contains(idSeparator) || id.contains(idSeparator)) {
             throw new IllegalArgumentException(String.format("Illegal arguments specified for column name creation (group = %s, id = %s)", group, id));

--- a/scheduled-actions-core/src/main/java/com/netflix/scheduledactions/persistence/InMemoryActionInstanceDao.java
+++ b/scheduled-actions-core/src/main/java/com/netflix/scheduledactions/persistence/InMemoryActionInstanceDao.java
@@ -27,6 +27,8 @@ public class InMemoryActionInstanceDao extends AbstractInMemoryDao<ActionInstanc
     public String createActionInstance(String group, ActionInstance actionInstance) {
         if (actionInstance.getId() == null) {
             actionInstance.setId(createId(group, UUID.randomUUID().toString()));
+        } else if (!isIdFormat(actionInstance.getId())) {
+            actionInstance.setId(createId(group, actionInstance.getId()));
         }
         create(group, actionInstance.getId(), actionInstance);
         return actionInstance.getId();

--- a/scheduled-actions-core/src/test/groovy/com/netflix/scheduledactions/persistence/InMemoryActionInstanceDaoSpec.groovy
+++ b/scheduled-actions-core/src/test/groovy/com/netflix/scheduledactions/persistence/InMemoryActionInstanceDaoSpec.groovy
@@ -1,0 +1,66 @@
+package com.netflix.scheduledactions.persistence
+
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.netflix.scheduledactions.ActionInstance
+import rx.functions.Action1
+import spock.lang.Specification
+
+class InMemoryActionInstanceDaoSpec extends Specification {
+
+  static class TestAction1 implements Action1<ActionInstance> {
+    @Override
+    void call(ActionInstance actionInstance) {}
+  }
+
+  def 'should create and update ActionInstance'() {
+    given:
+    def subject = new InMemoryActionInstanceDao()
+
+    when:
+    subject.createActionInstance(actionInstance.group, actionInstance)
+
+    then:
+    actionInstance == subject.getActionInstance(actionInstance.id)
+
+    when:
+    subject.updateActionInstance(actionInstance)
+
+    then:
+    actionInstance == subject.getActionInstance(actionInstance.id)
+
+    when:
+    def result = subject.getActionInstances(actionInstance.group)
+
+    then:
+    result == [actionInstance]
+
+    where:
+    actionInstance << [
+      ActionInstance.newActionInstance()
+        .withName("ID & Group defined")
+        .withId(UUID.randomUUID().toString())
+        .withGroup(UUID.randomUUID().toString())
+        .build(),
+      ActionInstance.newActionInstance()
+        .withName("Group defined")
+        .withGroup(UUID.randomUUID().toString())
+        .build()
+    ]
+
+  }
+}

--- a/scheduled-actions-core/src/test/groovy/com/netflix/scheduledactions/persistence/InMemoryDaoSpec.groovy
+++ b/scheduled-actions-core/src/test/groovy/com/netflix/scheduledactions/persistence/InMemoryDaoSpec.groovy
@@ -92,7 +92,6 @@ class InMemoryDaoSpec extends Specification {
         ActionInstance savedActionInstance = actionInstanceDao.getActionInstance(actionInstanceId)
 
         then:
-        then:
         savedActionInstance.id == actionInstanceId
         savedActionInstance.name == 'actionInstance1'
         savedActionInstance.owners == null


### PR DESCRIPTION
The InMemory scheduler in Echo doesn't work because the scheduled actions DAO doesn't correctly lookup ActionInstances that are created with the ID and group predefined, which was leading to an NPE on updates and deletes.

@spinnaker/netflix-reviewers PTAL